### PR TITLE
fix createDebugNodes

### DIFF
--- a/SumerianARKitStarter/ViewController.swift
+++ b/SumerianARKitStarter/ViewController.swift
@@ -70,7 +70,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
     // ARSCNViewDelegate
     func renderer(_ renderer: SCNSceneRenderer, nodeFor anchor: ARAnchor) -> SCNNode? {
         if !self.createDebugNodes {
-            return nil
+            return SCNNode()
         }
 
         let cube = SCNBox(width: 0.1, height: 0.1, length: 0.1, chamferRadius: 0.0)


### PR DESCRIPTION
fix anchorCallback method (in Sumerian) do not work when createDebugNodes is 'false'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
